### PR TITLE
little updates on readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ timeout: 1000
 
 - __ignore__ [Array]: provide a list of selectors that should not be removed by UnCSS. For example, styles added by user interaction with the page (hover, click), since those are not detectable by UnCSS yet. Both literal names and regex patterns are recognized.
 - __csspath__ [String]: Path where the CSS files are related to the html files. By default, UnCSS uses the path specified in the <link rel="stylesheet" href="path/to/file.css"\>
-- __stylesheets__ [Array]: Force the list of stylesheets to optimize using a path relative to the `Gruntfile.js`. Otherwise, it extracts the stylesheets from the html files.
+- __stylesheets__ [Array]: Force the list of stylesheets to optimize using a path relative to the `gulpfile.js`. Otherwise, it extracts the stylesheets from the html files.
 - __raw__ [String]: Give the task a raw string of CSS in addition to the existing stylesheet options; useful in scripting when your CSS hasn't yet been written to disk.
 - __timeout__ [Number]: Specify how long to wait for the JS to be loaded.
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ npm install --save-dev gulp-uncss-task
 
 ## Usage
 
-```
+```js
 var gulp = require('gulp');
 var uncss = require('gulp-uncss-task');
 


### PR DESCRIPTION
tiny little updates for the readme file.
- enable syntax highlighting for Usage code block (which is what I love to do for any readme files).
- correct `Gruntfile.js` to `gulpfile.js` which (I think) should be the correct one in `stylesheets` option.
