### PR TITLE
add deprecated in the title and give a link to gulp-uncss

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
-gulp-uncss-task
+gulp-uncss-task (deprecated)
 ===============
+
+**Note:** this module is deprecated in favor of [gulp-uncss](https://github.com/ben-eb/gulp-uncss).
 
 > A Gulp task for removing unused CSS
 


### PR DESCRIPTION
I think it would be great to add a link to gulp-uncss as people may not notice this is a deprecated module.
